### PR TITLE
Another set of fixes fixes for the graph/state machine generation functionality

### DIFF
--- a/serverlessworkflow/sdk/state_machine_generator.py
+++ b/serverlessworkflow/sdk/state_machine_generator.py
@@ -178,6 +178,11 @@ class StateMachineGenerator:
 
     def parallel_state_details(self):
         if isinstance(self.state, ParallelState):
+            if self.state.name not in self.state_machine.states.keys():
+                self.state_machine.add_states(self.state.name)
+            if self.is_first_state:
+                self.state_machine._initial = self.state.name
+
             state_name = self.state.name
             branches = self.state.branches
             if branches:
@@ -208,8 +213,8 @@ class StateMachineGenerator:
     def operation_state_details(self):
         if self.state.name not in self.state_machine.states.keys():
             self.state_machine.add_states(self.state.name)
-            if self.is_first_state:
-                self.state_machine._initial = self.state.name
+        if self.is_first_state:
+            self.state_machine._initial = self.state.name
 
         if isinstance(self.state, OperationState):
             self.generate_actions_info(
@@ -264,11 +269,11 @@ class StateMachineGenerator:
                         )
 
                         # Generate the state machine for the subflow
-                        for index, state in enumerate(sf.states):
+                        for state in sf.states:
                             StateMachineGenerator(
                                 state=state,
                                 state_machine=new_machine,
-                                is_first_state=index == 0,
+                                is_first_state=sf.start == state.name,
                                 get_actions=self.get_actions,
                                 subflows=self.subflows,
                             ).generate()

--- a/serverlessworkflow/sdk/state_machine_helper.py
+++ b/serverlessworkflow/sdk/state_machine_helper.py
@@ -30,11 +30,11 @@ class StateMachineHelper:
             auto_transitions=False,
             title=title,
         )
-        for index, state in enumerate(workflow.states):
+        for state in workflow.states:
             StateMachineGenerator(
                 state=state,
                 state_machine=self.machine,
-                is_first_state=index == 0,
+                is_first_state=workflow.start == state.name,
                 get_actions=self.get_actions,
                 subflows=subflows,
             ).generate()


### PR DESCRIPTION
This PR adds multiple bug fixes for the feature implemented in https://github.com/serverlessworkflow/sdk-python/pull/30:
- The initial state of the state machine was obtained as the first state listed in the workflow. This was because the code in the TypeScript SDK was implemented in this manner. Now, the code checks for the `start` state.
- Whenever a parallel state was the first one in the workflow, the state machine generator would throw an error. This was because the code was not creating the state in that specific case.