### PR TITLE
Adding metadata to events

### DIFF
--- a/serverlessworkflow/sdk/on_events.py
+++ b/serverlessworkflow/sdk/on_events.py
@@ -19,7 +19,7 @@ class OnEvents(SwfBase):
                  **kwargs):
 
         _default_values = {'actionMode': 'sequential'}
-        SwfBase.__init__(self, locals(), kwargs, SwfBase.default_hydration, _default_values)
+        SwfBase.__init__(self, locals(), kwargs, OnEvents.f_hydration, _default_values)
 
     @staticmethod
     def f_hydration(p_key, p_value):

--- a/serverlessworkflow/sdk/state_machine_generator.py
+++ b/serverlessworkflow/sdk/state_machine_generator.py
@@ -23,7 +23,6 @@ from serverlessworkflow.sdk.workflow import (
 from serverlessworkflow.sdk.transition_data_condition import TransitionDataCondition
 from serverlessworkflow.sdk.end_data_condition import EndDataCondition
 
-from transitions.extensions import HierarchicalMachine, GraphMachine
 from transitions.extensions.nesting import NestedState
 import warnings
 

--- a/serverlessworkflow/sdk/state_machine_generator.py
+++ b/serverlessworkflow/sdk/state_machine_generator.py
@@ -447,7 +447,11 @@ class StateMachineGenerator:
                                 ns := self.state_machine.state_cls(name)
                             )
                             ns.tags = ["event"]
-                            self.get_action_event(state=ns, e_name=name)
+                            self.get_action_event(
+                                state=ns,
+                                e_name=action.eventRef.triggerEventRef,
+                                er_name=action.eventRef.resultEventRef,
+                            )
                     if name:
                         if action_mode == "sequential":
                             if i < len(actions) - 1:
@@ -499,7 +503,9 @@ class StateMachineGenerator:
                                         )
                                         ns.tags = ["event"]
                                         self.get_action_event(
-                                            state=ns, e_name=next_name
+                                            state=ns,
+                                            e_name=action.eventRef.triggerEventRef,
+                                            er_name=action.eventRef.resultEventRef,
                                         )
                                 self.state_machine.add_transition(
                                     trigger="",
@@ -536,13 +542,14 @@ class StateMachineGenerator:
                     state.metadata = {"function": current_function}
                     break
 
-    def get_action_event(self, state: NestedState, e_name: str):
+    def get_action_event(self, state: NestedState, e_name: str, er_name: str = ""):
         if self.workflow.events:
             for event in self.workflow.events:
                 current_event = event.serialize().__dict__
                 if current_event["name"] == e_name:
                     state.metadata = {"event": current_event}
-                    break
+                if current_event["name"] == er_name:
+                    state.metadata = {"result_event": current_event}
 
     def subflow_state_name(self, action: Action, subflow: Workflow):
         return (

--- a/serverlessworkflow/sdk/state_machine_helper.py
+++ b/serverlessworkflow/sdk/state_machine_helper.py
@@ -1,13 +1,10 @@
 from typing import List
 from serverlessworkflow.sdk.workflow import Workflow
 from serverlessworkflow.sdk.state_machine_generator import StateMachineGenerator
-from transitions.extensions.diagrams import HierarchicalGraphMachine, GraphMachine
 from serverlessworkflow.sdk.state_machine_extensions import (
     CustomGraphMachine,
     CustomHierarchicalGraphMachine,
 )
-from transitions.extensions.nesting import NestedState
-from transitions.extensions.diagrams_base import BaseGraph
 
 
 class StateMachineHelper:


### PR DESCRIPTION
This PR adds more support for feature implemented in https://github.com/serverlessworkflow/sdk-python/pull/35:
- Now, events are added to states that have them in the workflow (including their metadata with all the event information).